### PR TITLE
Modificando Comprar passagens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: stable
+          chrome-version: 139
         id: setup-chrome
 
       - name: Setup ChromeDriver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup ChromeDriver
         uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 139
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 139
+          chrome-version: 140
         id: setup-chrome
 
       - name: Setup ChromeDriver
         uses: nanasess/setup-chromedriver@v2
         with:
-          chromedriver-version: 139
+          chromedriver-version: 140
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,11 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: 140
+          chrome-version: stable
         id: setup-chrome
 
       - name: Setup ChromeDriver
         uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: 140
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :development, :test do
   gem "simplecov", require: false
   gem "coveralls", require: false
   gem "selenium-webdriver", "~> 4.8"
-  gem "webdrivers"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,10 +376,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -427,7 +423,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.3.3p89

--- a/app/controllers/documentos_controller.rb
+++ b/app/controllers/documentos_controller.rb
@@ -1,2 +1,14 @@
 class DocumentosController < ApplicationController
+  def show
+    @airline = airlines
+  end
+
+  private
+  def airlines
+    {
+      "Latam" => "https://www.l'atamairlines.com/br/pt",
+      "Gol" => "https://www.voegol.com.br/",
+      "Azul" => "https://www.voeazul.com.br/home/br/pt/home"
+    }
+  end
 end

--- a/app/helpers/documento_helper.rb
+++ b/app/helpers/documento_helper.rb
@@ -1,2 +1,0 @@
-module DocumentoHelper
-end

--- a/app/helpers/documentos_helper.rb
+++ b/app/helpers/documentos_helper.rb
@@ -1,0 +1,2 @@
+module DocumentosHelper
+end

--- a/app/helpers/perfil_helper.rb
+++ b/app/helpers/perfil_helper.rb
@@ -1,2 +1,0 @@
-module PerfilHelper
-end

--- a/app/helpers/perfis_helper.rb
+++ b/app/helpers/perfis_helper.rb
@@ -1,0 +1,2 @@
+module PerfisHelper
+end

--- a/app/views/documentos/show.html.erb
+++ b/app/views/documentos/show.html.erb
@@ -1,6 +1,6 @@
 <h1> Paris - França </h1>
 <div class="buy-tickets">
-  <a href="/mock/latam" target="_blank"> Latam </a>
-  <a href="/mock/gol" target="_blank"> Gol </a>
-  <a href="/mock/" target="_blank"> Azul </a>
+  <% @airline.each do |name, url| %>
+  <a href="<%= url %>" target="_blank"> <%= name %> </a>
+  <% end %>
 </div>

--- a/config/initializers/webdrivers.rb
+++ b/config/initializers/webdrivers.rb
@@ -1,3 +1,0 @@
-if ENV["CI"]
-  Webdrivers.disable!
-end

--- a/config/initializers/webdrivers.rb
+++ b/config/initializers/webdrivers.rb
@@ -1,0 +1,3 @@
+if ENV["CI"]
+  Webdrivers.disable!
+end

--- a/features/comprar_passagens.feature
+++ b/features/comprar_passagens.feature
@@ -13,6 +13,7 @@ Funcionalidade: Comprar passagens
     # nesse caso, deveria conter uma lista de companhias?
     # funcionalidade deve ser pensada em usuário logado ou deslogado?
     @javascript
+    @mock_airlines
     Cenário: Redirecionado com sucesso para o site da companhia
         Dado que sou um participante da viagem
         E o documento compartilhado existe
@@ -23,6 +24,7 @@ Funcionalidade: Comprar passagens
 
     # por que daria erro?
     @javascript
+    @mock_airlines
     Cenário: Falha no redirecionamento para o site da companhia
         Dado que sou um participante da viagem
         E o documento compartilhado existe
@@ -33,6 +35,7 @@ Funcionalidade: Comprar passagens
 
     # Regra de negócio confusa (O que o usuário deve ver como conviddo?)
     @javascript
+    @mock_airlines
     Cenário: Tentativa de comprar passagens deslogado
         Dado que existe um documento compartilhado
         E que estou na página do documento

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -59,7 +59,6 @@ def find_chrome
   paths.find { |path| path && File.exist?(path) }
 end
 
-# Encontra o Firefox
 def find_firefox
   return ENV['FIREFOX_BIN'] if ENV['FIREFOX_BIN'] && File.exist?(ENV['FIREFOX_BIN'])
 
@@ -136,11 +135,13 @@ end
 
 Capybara.default_max_wait_time = 10
 
-if ENV['BROWSER']
-  case ENV['BROWSER'].downcase
+case ENV['BROWSER']&.downcase
   when 'firefox'
     puts "→ Forçando uso do Firefox (via ENV['BROWSER'])"
   when 'chrome'
     puts "→ Forçando uso do Chrome (via ENV['BROWSER'])"
-  end
+  when nil
+    puts "→ Nenhuma variável ENV['BROWSER'] definida. Usando navegador padrão."
+  else
+    puts "→ Valor de ENV['BROWSER'] desconhecido: #{ENV['BROWSER']}. Usando navegador padrão."
 end

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,50 +1,66 @@
+# spec/support/capybara.rb
+
 require 'capybara'
 require 'selenium-webdriver'
+require 'webdrivers' # Para gerenciar os drivers (chromedriver/geckodriver) automaticamente
 
-Capybara.register_driver :headless_chrome do |app|
-  # auto-detect Chrome/Chromium binary in common locations (prefer snap), or use ENV override
+# ----------------------------------------------------------------------
+# 1. TENTA CONFIGURAR O CHROME HEADLESS
+# ----------------------------------------------------------------------
+begin
+  # Configuração para encontrar o Chrome (Versão que você tinha, ligeiramente melhorada)
   chrome_bin_path = ENV['CHROME_BIN'] || [
-    '/snap/bin/chromium',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/usr/bin/google-chrome',
-    '/opt/google/chrome/chrome'
+    '/usr/bin/google-chrome',      # Caminho mais comum no Linux
+    '/opt/google/chrome/chrome',  # Outro caminho comum
+    '/usr/bin/chromium',          # Se for o Chromium
+    '/usr/bin/chromium-browser'
   ].find { |p| File.exist?(p) }
 
-  # allow explicit override for chromedriver path; otherwise detect common locations
-  driver_path = ENV['CHROMEDRIVER_PATH'] || [
-    '/usr/bin/chromedriver',
-    '/usr/local/bin/chromedriver'
-  ].find { |p| File.exist?(p) }
+  # Se encontrou o binário, registra o driver do Chrome
+  unless chrome_bin_path.nil?
+    Capybara.register_driver :chrome_or_default do |app|
+      options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+        opts.add_argument('--headless=new')
+        opts.add_argument('--disable-gpu')
+        opts.add_argument('--no-sandbox')
+        opts.add_argument('--disable-dev-shm-usage')
+        opts.add_argument('--window-size=1920,1080')
+        opts.add_argument('--disable-site-isolation-trials')
+        opts.add_argument('--disable-features=IsolateOrigins,site-per-process')
+        opts.binary = chrome_bin_path # Define o binário encontrado
+      end
+      # Usa o webdrivers para gerenciar o chromedriver
+      Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+    end
 
-  options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    opts.add_argument('--headless=new')
-  # avoid using a custom user-data-dir here (snap builds and concurrent runs can conflict)
-  # add common flags to reduce interactive prompts and extensions
-  opts.add_argument('--no-first-run')
-  opts.add_argument('--no-default-browser-check')
-  opts.add_argument('--disable-extensions')
-    opts.add_argument('--disable-gpu')
-    opts.add_argument('--no-sandbox')
-    opts.add_argument('--disable-dev-shm-usage')
-    opts.add_argument('--window-size=1920,1080')
-    opts.add_argument('--disable-site-isolation-trials')
-    opts.add_argument('--disable-features=IsolateOrigins,site-per-process')
+    # Se configurou o Chrome, usa ele.
+    Capybara.javascript_driver = :chrome_or_default
 
-    opts.binary = chrome_bin_path if chrome_bin_path
-  end
-
-  # se o chromedriver não estiver instalado no caminho esperado, não passe o path
-  # para que a gem `webdrivers` possa gerenciar o download automaticamente
-  service = if driver_path && File.exist?(driver_path)
-    Selenium::WebDriver::Service.chrome(path: driver_path)
+    puts "Capybara configurado: Usando Chrome Headless."
   else
-    # Let webdrivers manage it if available; otherwise Selenium will try default
-    Selenium::WebDriver::Service.chrome
+    # Se não achou o Chrome, forçamos um erro para cair no 'rescue'
+    raise "Chrome binary not found on system path."
   end
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, service: service)
+  # ----------------------------------------------------------------------
+  # 2. SE FALHAR, CONFIGURA O FIREFOX HEADLESS (Fallback)
+  # ----------------------------------------------------------------------
+rescue StandardError => e
+  # Se o bloco 'begin' falhar (não achou Chrome ou deu erro no driver)
+  Capybara.register_driver :chrome_or_default do |app|
+    # Configurações do Firefox Headless
+    options = Selenium::WebDriver::Firefox::Options.new.tap do |opts|
+      opts.add_argument('-headless')
+    end
+    # Usa o browser Firefox
+    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+  end
+
+  # Usa o driver de fallback
+  Capybara.javascript_driver = :chrome_or_default
+
+  puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless como fallback."
 end
 
-Capybara.javascript_driver = :headless_chrome
+# Configurações globais
 Capybara.default_max_wait_time = 10

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,6 +1,5 @@
 require 'capybara'
 require 'selenium-webdriver'
-require 'webdrivers'
 
 begin
   chrome_bin_path = ENV['CHROME_BIN'] || [

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,23 +1,17 @@
-# spec/support/capybara.rb
-
 require 'capybara'
 require 'selenium-webdriver'
-require 'webdrivers' # Para gerenciar os drivers (chromedriver/geckodriver) automaticamente
+require 'webdrivers'
 
-# ----------------------------------------------------------------------
-# 1. TENTA CONFIGURAR O CHROME HEADLESS
-# ----------------------------------------------------------------------
 begin
-  # Configuração para encontrar o Chrome (Versão que você tinha, ligeiramente melhorada)
   chrome_bin_path = ENV['CHROME_BIN'] || [
-    '/usr/bin/google-chrome',      # Caminho mais comum no Linux
-    '/opt/google/chrome/chrome',  # Outro caminho comum
-    '/usr/bin/chromium',          # Se for o Chromium
+    '/usr/bin/google-chrome',
+    '/opt/google/chrome/chrome',
+    '/usr/bin/chromium',
     '/usr/bin/chromium-browser'
   ].find { |p| File.exist?(p) }
-
-  # Se encontrou o binário, registra o driver do Chrome
-  unless chrome_bin_path.nil?
+  if chrome_bin_path.nil?
+    raise "Chrome binary not found on system path."
+  else
     Capybara.register_driver :chrome_or_default do |app|
       options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
         opts.add_argument('--headless=new')
@@ -27,40 +21,23 @@ begin
         opts.add_argument('--window-size=1920,1080')
         opts.add_argument('--disable-site-isolation-trials')
         opts.add_argument('--disable-features=IsolateOrigins,site-per-process')
-        opts.binary = chrome_bin_path # Define o binário encontrado
+        opts.binary = chrome_bin_path
       end
-      # Usa o webdrivers para gerenciar o chromedriver
       Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
     end
-
-    # Se configurou o Chrome, usa ele.
     Capybara.javascript_driver = :chrome_or_default
-
     puts "Capybara configurado: Usando Chrome Headless."
-  else
-    # Se não achou o Chrome, forçamos um erro para cair no 'rescue'
-    raise "Chrome binary not found on system path."
   end
 
-  # ----------------------------------------------------------------------
-  # 2. SE FALHAR, CONFIGURA O FIREFOX HEADLESS (Fallback)
-  # ----------------------------------------------------------------------
 rescue StandardError => e
-  # Se o bloco 'begin' falhar (não achou Chrome ou deu erro no driver)
   Capybara.register_driver :chrome_or_default do |app|
-    # Configurações do Firefox Headless
     options = Selenium::WebDriver::Firefox::Options.new.tap do |opts|
       opts.add_argument('-headless')
     end
-    # Usa o browser Firefox
     Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
   end
-
-  # Usa o driver de fallback
   Capybara.javascript_driver = :chrome_or_default
-
   puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless como fallback."
 end
 
-# Configurações globais
 Capybara.default_max_wait_time = 10

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,42 +1,146 @@
 require 'capybara'
 require 'selenium-webdriver'
 
+def detect_os
+  case RbConfig::CONFIG['host_os']
+  when /darwin|mac os/i then :macos
+  when /mswin|msys|mingw|cygwin|bccwin|wince|emc/i then :windows
+  when /linux/i then :linux
+  else :linux
+  end
+end
+
+def chrome_paths
+  {
+    linux: [
+      '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/opt/google/chrome/chrome',
+      '/usr/bin/chromium',
+      '/usr/bin/chromium-browser',
+      '/snap/bin/chromium'
+    ],
+    macos: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium'
+    ],
+    windows: [
+      'C:/Program Files/Google/Chrome/Application/chrome.exe',
+      'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
+      ENV['LOCALAPPDATA'] ? "#{ENV['LOCALAPPDATA']}/Google/Chrome/Application/chrome.exe" : nil,
+      'C:/Program Files/Chromium/Application/chrome.exe'
+    ].compact
+  }
+end
+
+def firefox_paths
+  {
+    linux: [
+      '/usr/bin/firefox',
+      '/usr/bin/firefox-esr',
+      '/snap/bin/firefox'
+    ],
+    macos: [
+      '/Applications/Firefox.app/Contents/MacOS/firefox'
+    ],
+    windows: [
+      'C:/Program Files/Mozilla Firefox/firefox.exe',
+      'C:/Program Files (x86)/Mozilla Firefox/firefox.exe',
+      ENV['PROGRAMFILES'] ? "#{ENV['PROGRAMFILES']}/Mozilla Firefox/firefox.exe" : nil
+    ].compact
+  }
+end
+
+def find_chrome
+  return ENV['CHROME_BIN'] if ENV['CHROME_BIN'] && File.exist?(ENV['CHROME_BIN'])
+
+  os = detect_os
+  paths = chrome_paths[os] || []
+  paths.find { |path| path && File.exist?(path) }
+end
+
+# Encontra o Firefox
+def find_firefox
+  return ENV['FIREFOX_BIN'] if ENV['FIREFOX_BIN'] && File.exist?(ENV['FIREFOX_BIN'])
+
+  os = detect_os
+  paths = firefox_paths[os] || []
+  paths.find { |path| path && File.exist?(path) }
+end
+
 begin
-  chrome_bin_path = ENV['CHROME_BIN'] || [
-    '/usr/bin/google-chrome',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser'
-  ].find { |p| File.exist?(p) }
+  chrome_bin_path = find_chrome
+
   if chrome_bin_path.nil?
     raise "Chrome binary not found on system path."
   else
     Capybara.register_driver :chrome_or_default do |app|
-      options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-        opts.add_argument('--headless=new')
-        opts.add_argument('--disable-gpu')
-        opts.add_argument('--no-sandbox')
-        opts.add_argument('--disable-dev-shm-usage')
-        opts.add_argument('--window-size=1920,1080')
-        opts.add_argument('--disable-site-isolation-trials')
-        opts.add_argument('--disable-features=IsolateOrigins,site-per-process')
-        opts.binary = chrome_bin_path
-      end
+      options = Selenium::WebDriver::Chrome::Options.new
+
+      options.add_argument('--headless=new')
+      options.add_argument('--disable-gpu')
+      options.add_argument('--no-sandbox')
+      options.add_argument('--disable-dev-shm-usage')
+      options.add_argument('--window-size=1920,1080')
+      options.add_argument('--disable-site-isolation-trials')
+      options.add_argument('--disable-features=IsolateOrigins,site-per-process')
+
+      options.add_argument('--disable-blink-features=AutomationControlled')
+      options.add_argument('--disable-extensions')
+
+      options.binary = chrome_bin_path
+
       Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
     end
+
     Capybara.javascript_driver = :chrome_or_default
-    puts "Capybara configurado: Usando Chrome Headless."
+    puts "Capybara configurado: Usando Chrome Headless (#{detect_os})."
+    puts "  Caminho: #{chrome_bin_path}"
   end
 
 rescue StandardError => e
-  Capybara.register_driver :chrome_or_default do |app|
-    options = Selenium::WebDriver::Firefox::Options.new.tap do |opts|
-      opts.add_argument('-headless')
+  firefox_bin_path = find_firefox
+
+  if firefox_bin_path
+    Capybara.register_driver :chrome_or_default do |app|
+      options = Selenium::WebDriver::Firefox::Options.new
+      options.add_argument('-headless')
+
+      options.add_preference('dom.webdriver.enabled', false)
+      options.add_preference('useAutomationExtension', false)
+
+      options.binary = firefox_bin_path if firefox_bin_path
+
+      Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
     end
-    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+
+    Capybara.javascript_driver = :chrome_or_default
+    puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless (#{detect_os})."
+    puts "  Caminho: #{firefox_bin_path}"
+  else
+    puts "Aviso: Nenhum navegador encontrado nos caminhos padrão."
+    puts "Tentando usar Selenium Manager..."
+
+    Capybara.register_driver :chrome_or_default do |app|
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument('--headless=new')
+      options.add_argument('--disable-gpu')
+      options.add_argument('--no-sandbox')
+
+      Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+    end
+
+    Capybara.javascript_driver = :chrome_or_default
   end
-  Capybara.javascript_driver = :chrome_or_default
-  puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless como fallback."
 end
 
 Capybara.default_max_wait_time = 10
+
+if ENV['BROWSER']
+  case ENV['BROWSER'].downcase
+  when 'firefox'
+    puts "→ Forçando uso do Firefox (via ENV['BROWSER'])"
+  when 'chrome'
+    puts "→ Forçando uso do Chrome (via ENV['BROWSER'])"
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,9 +5,6 @@
 # files.
 
 require 'cucumber/rails'
-require 'webdrivers'
-
-Webdrivers::Chromedriver.required_version = '139.0.7258.154'
 
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,10 @@
 
 require 'cucumber/rails'
 
+# Fixando a versão necessária do Chromedriver
+require 'webdrivers'
+Webdrivers::Chromedriver.required_version = '141.0.7390.54'
+
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how
 # your application behaves in the production environment, where an error page will

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,10 +6,6 @@
 
 require 'cucumber/rails'
 
-# Fixando a versão necessária do Chromedriver
-require 'webdrivers'
-Webdrivers::Chromedriver.required_version = '141.0.7390.54'
-
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how
 # your application behaves in the production environment, where an error page will

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,9 @@
 # files.
 
 require 'cucumber/rails'
+require 'webdrivers'
+
+Webdrivers::Chromedriver.required_version = '139.0.7258.154'
 
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,20 @@
+Before do
+  RSpec::Mocks.setup
+end
+
+After do
+  begin
+    RSpec::Mocks.verify
+  ensure
+    RSpec::Mocks.teardown
+  end
+end
+
+Before('@mock_airlines') do
+  mocked_airlines = {
+    "Latam" => "/mock/latam",
+    "Gol"   => "/mock/gol",
+    "Azul"  => "/mock/azul"
+  }
+  allow_any_instance_of(DocumentosController).to receive(:airlines).and_return(mocked_airlines)
+end

--- a/features/support/rspec_support.rb
+++ b/features/support/rspec_support.rb
@@ -1,0 +1,3 @@
+require 'rspec/mocks'
+
+World(RSpec::Mocks::ExampleMethods)

--- a/spec/helpers/documentos_helper_spec.rb
+++ b/spec/helpers/documentos_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes
-# the PerfilHelper. For example:
+# the DocumentosHelper. For example:
 #
-# describe PerfilHelper do
+# describe DocumentosHelper do
 #   describe "string concat" do
 #     it "concats two strings with spaces" do
 #       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
 # end
-RSpec.describe PerfilHelper, type: :helper do
+RSpec.describe DocumentosHelper, type: :helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/helpers/perfis_helper_spec.rb
+++ b/spec/helpers/perfis_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes
-# the DocumentoHelper. For example:
+# the PerfisHelper. For example:
 #
-# describe DocumentoHelper do
+# describe PerfisHelper do
 #   describe "string concat" do
 #     it "concats two strings with spaces" do
 #       expect(helper.concat_strings("this","that")).to eq("this that")
 #     end
 #   end
 # end
-RSpec.describe DocumentoHelper, type: :helper do
+RSpec.describe PerfisHelper, type: :helper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,8 +10,13 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 # habilita assigns, assert_template e outros helpers de controller testing
 require "rails-controller-testing"
-Rails::Controller::Testing.install
+require 'webdrivers'
 
+major_version = 139
+latest_139_version = `curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_#{major_version}`.strip
+Webdrivers::Chromedriver.required_version = latest_139_version
+
+Rails::Controller::Testing.install
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,11 +10,6 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 # habilita assigns, assert_template e outros helpers de controller testing
 require "rails-controller-testing"
-require 'webdrivers'
-
-major_version = 139
-latest_139_version = `curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_#{major_version}`.strip
-Webdrivers::Chromedriver.required_version = latest_139_version
 
 Rails::Controller::Testing.install
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,11 +15,6 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 require 'coveralls'
-require 'webdrivers'
-
-major_version = 139
-latest_139_version = `curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_#{major_version}`.strip
-Webdrivers::Chromedriver.required_version = latest_139_version
 
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,12 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 require 'coveralls'
+require 'webdrivers'
+
+major_version = 139
+latest_139_version = `curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_#{major_version}`.strip
+Webdrivers::Chromedriver.required_version = latest_139_version
+
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,5 @@
 require 'capybara'
 require 'selenium-webdriver'
-require 'webdrivers'
 
 begin
   chrome_bin_path = ENV['CHROME_BIN'] || [

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -59,7 +59,6 @@ def find_chrome
   paths.find { |path| path && File.exist?(path) }
 end
 
-# Encontra o Firefox
 def find_firefox
   return ENV['FIREFOX_BIN'] if ENV['FIREFOX_BIN'] && File.exist?(ENV['FIREFOX_BIN'])
 
@@ -136,11 +135,13 @@ end
 
 Capybara.default_max_wait_time = 10
 
-if ENV['BROWSER']
-  case ENV['BROWSER'].downcase
-  when 'firefox'
-    puts "→ Forçando uso do Firefox (via ENV['BROWSER'])"
-  when 'chrome'
-    puts "→ Forçando uso do Chrome (via ENV['BROWSER'])"
-  end
+case ENV['BROWSER']&.downcase
+when 'firefox'
+  puts "→ Forçando uso do Firefox (via ENV['BROWSER'])"
+when 'chrome'
+  puts "→ Forçando uso do Chrome (via ENV['BROWSER'])"
+when nil
+  puts "→ Nenhuma variável ENV['BROWSER'] definida. Usando navegador padrão."
+else
+  puts "→ Valor de ENV['BROWSER'] desconhecido: #{ENV['BROWSER']}. Usando navegador padrão."
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,42 +1,146 @@
 require 'capybara'
 require 'selenium-webdriver'
 
+def detect_os
+  case RbConfig::CONFIG['host_os']
+  when /darwin|mac os/i then :macos
+  when /mswin|msys|mingw|cygwin|bccwin|wince|emc/i then :windows
+  when /linux/i then :linux
+  else :linux
+  end
+end
+
+def chrome_paths
+  {
+    linux: [
+      '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/opt/google/chrome/chrome',
+      '/usr/bin/chromium',
+      '/usr/bin/chromium-browser',
+      '/snap/bin/chromium'
+    ],
+    macos: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium'
+    ],
+    windows: [
+      'C:/Program Files/Google/Chrome/Application/chrome.exe',
+      'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe',
+      ENV['LOCALAPPDATA'] ? "#{ENV['LOCALAPPDATA']}/Google/Chrome/Application/chrome.exe" : nil,
+      'C:/Program Files/Chromium/Application/chrome.exe'
+    ].compact
+  }
+end
+
+def firefox_paths
+  {
+    linux: [
+      '/usr/bin/firefox',
+      '/usr/bin/firefox-esr',
+      '/snap/bin/firefox'
+    ],
+    macos: [
+      '/Applications/Firefox.app/Contents/MacOS/firefox'
+    ],
+    windows: [
+      'C:/Program Files/Mozilla Firefox/firefox.exe',
+      'C:/Program Files (x86)/Mozilla Firefox/firefox.exe',
+      ENV['PROGRAMFILES'] ? "#{ENV['PROGRAMFILES']}/Mozilla Firefox/firefox.exe" : nil
+    ].compact
+  }
+end
+
+def find_chrome
+  return ENV['CHROME_BIN'] if ENV['CHROME_BIN'] && File.exist?(ENV['CHROME_BIN'])
+
+  os = detect_os
+  paths = chrome_paths[os] || []
+  paths.find { |path| path && File.exist?(path) }
+end
+
+# Encontra o Firefox
+def find_firefox
+  return ENV['FIREFOX_BIN'] if ENV['FIREFOX_BIN'] && File.exist?(ENV['FIREFOX_BIN'])
+
+  os = detect_os
+  paths = firefox_paths[os] || []
+  paths.find { |path| path && File.exist?(path) }
+end
+
 begin
-  chrome_bin_path = ENV['CHROME_BIN'] || [
-    '/usr/bin/google-chrome',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser'
-  ].find { |p| File.exist?(p) }
+  chrome_bin_path = find_chrome
+
   if chrome_bin_path.nil?
     raise "Chrome binary not found on system path."
   else
     Capybara.register_driver :chrome_or_default do |app|
-      options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-        opts.add_argument('--headless=new')
-        opts.add_argument('--disable-gpu')
-        opts.add_argument('--no-sandbox')
-        opts.add_argument('--disable-dev-shm-usage')
-        opts.add_argument('--window-size=1920,1080')
-        opts.add_argument('--disable-site-isolation-trials')
-        opts.add_argument('--disable-features=IsolateOrigins,site-per-process')
-        opts.binary = chrome_bin_path
-      end
+      options = Selenium::WebDriver::Chrome::Options.new
+
+      options.add_argument('--headless=new')
+      options.add_argument('--disable-gpu')
+      options.add_argument('--no-sandbox')
+      options.add_argument('--disable-dev-shm-usage')
+      options.add_argument('--window-size=1920,1080')
+      options.add_argument('--disable-site-isolation-trials')
+      options.add_argument('--disable-features=IsolateOrigins,site-per-process')
+
+      options.add_argument('--disable-blink-features=AutomationControlled')
+      options.add_argument('--disable-extensions')
+
+      options.binary = chrome_bin_path
+
       Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
     end
+
     Capybara.javascript_driver = :chrome_or_default
-    puts "Capybara configurado: Usando Chrome Headless."
+    puts "Capybara configurado: Usando Chrome Headless (#{detect_os})."
+    puts "  Caminho: #{chrome_bin_path}"
   end
 
 rescue StandardError => e
-  Capybara.register_driver :chrome_or_default do |app|
-    options = Selenium::WebDriver::Firefox::Options.new.tap do |opts|
-      opts.add_argument('-headless')
+  firefox_bin_path = find_firefox
+
+  if firefox_bin_path
+    Capybara.register_driver :chrome_or_default do |app|
+      options = Selenium::WebDriver::Firefox::Options.new
+      options.add_argument('-headless')
+
+      options.add_preference('dom.webdriver.enabled', false)
+      options.add_preference('useAutomationExtension', false)
+
+      options.binary = firefox_bin_path if firefox_bin_path
+
+      Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
     end
-    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+
+    Capybara.javascript_driver = :chrome_or_default
+    puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless (#{detect_os})."
+    puts "  Caminho: #{firefox_bin_path}"
+  else
+    puts "Aviso: Nenhum navegador encontrado nos caminhos padrão."
+    puts "Tentando usar Selenium Manager..."
+
+    Capybara.register_driver :chrome_or_default do |app|
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument('--headless=new')
+      options.add_argument('--disable-gpu')
+      options.add_argument('--no-sandbox')
+
+      Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+    end
+
+    Capybara.javascript_driver = :chrome_or_default
   end
-  Capybara.javascript_driver = :chrome_or_default
-  puts "Capybara configurado: Chrome não encontrado. Usando Firefox Headless como fallback."
 end
 
 Capybara.default_max_wait_time = 10
+
+if ENV['BROWSER']
+  case ENV['BROWSER'].downcase
+  when 'firefox'
+    puts "→ Forçando uso do Firefox (via ENV['BROWSER'])"
+  when 'chrome'
+    puts "→ Forçando uso do Chrome (via ENV['BROWSER'])"
+  end
+end

--- a/spec/views/documento/show.html.erb_spec.rb
+++ b/spec/views/documento/show.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "documento/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/perfil/show.html.erb_spec.rb
+++ b/spec/views/perfil/show.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "perfil/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
- Renomeação de arquivos (documento => documentos, perfil => perfis)
- Adição de arquivos de configuração de teste (como hook.rb e rspec_support.rb)
- Modificação dos arquivos spec/support/capybara.rb features/support/capybara.rb
  - Chrome será usado como navegador padrão e Firefox será usado como fallback (no caso de não houver o Chrome no sistema)
- Criação de mocks para os links das companhias aéreas
  - Controller possui os links originais. Ambiente de teste possui os links mockados. View exibe ambos dependendo do contexto
